### PR TITLE
expose port in docker file

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -12,4 +12,5 @@ RUN apt update && apt install git -y
 RUN pip install poetry && poetry install
 
 # run the application
+EXPOSE 8000
 CMD [ "poetry", "run", "./run.py" ]

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,16 +1,30 @@
+# Use the specified Python version
 FROM python:3.11.4-slim-buster
 
-# set workdir
-WORKDIR /code
+# Configure Poetry
+ENV POETRY_VERSION=1.6.1
+ENV POETRY_HOME=/opt/poetry
+ENV POETRY_VENV=/opt/poetry-venv
+ENV POETRY_CACHE_DIR=/opt/.cache
 
-# copy the flask app to the working directory
-COPY ./ .
+# Install poetry separated from system interpreter
+RUN python3 -m venv $POETRY_VENV \
+    && $POETRY_VENV/bin/pip install -U pip setuptools \
+    && $POETRY_VENV/bin/pip install poetry==${POETRY_VERSION}
 
-# install the dependencies
-RUN apt update && apt install git -y
+# Add `poetry` to PATH
+ENV PATH="${PATH}:${POETRY_VENV}/bin"
 
-RUN pip install poetry && poetry install
+# Set the working directory
+WORKDIR /app
 
-# run the application
+# Install dependencies
+COPY poetry.lock pyproject.toml ./
+RUN poetry install
+
+# Copy the flask app to the working directory
+COPY . /app
+
+# Run the application
 EXPOSE 8000
-CMD [ "poetry", "run", "./run.py" ]
+CMD [ "poetry", "run", "python", "./run.py" ]


### PR DESCRIPTION
hopefully this fixes the recent glcoud deployment error
```
The user-provided container failed to start and listen on the port defined provided by the PORT=8080 environment variable
```
otherwise @josehelps has to check the glcoud configuration as the error states something about port 8080 but we always used 8000