### PR TITLE
add url parameter for rule sharing over link

### DIFF
--- a/static/js/index.js
+++ b/static/js/index.js
@@ -25,11 +25,35 @@ new TomSelect("#select-pipeline", {
 
 // inital stuff todo when page is loaded
 window.onload = function () {
-  // select splunk backend by default
+  const urlParameter = new URL(window.location.toLocaleString()).searchParams;
+  
+  // check if rule parameter is in url
+  if(urlParameter.has('rule')){
+    let rule = atob(urlParameter.get('rule'));
+    sigmaJar.updateCode(rule)
+  }
+
   let backendSelect = document.getElementById("select-backend");
-  backendSelect.tomselect.addItem("splunk");
-  // init filtering of dropdowns on page load
+  // get parameter backend from url and check if it's a valid option
+  if(urlParameter.has('backend') && backendSelect.querySelectorAll('option[value$="' + urlParameter.get('backend') + '"]').length > 0) {
+    // select item in dropdown
+    backendSelect.tomselect.addItem(urlParameter.get('backend'));
+  }
+  else { 
+    // select splunk backend as default
+    backendSelect.tomselect.addItem("splunk");
+  }
+
+  // only show formats for selected backend
   filterFormatOptions();
+
+  // get parameter format and select item in dropdown
+  let formatSelect = document.getElementById("select-format");
+  if(urlParameter.has('format')) {
+    formatSelect.tomselect.addItem(urlParameter.get('format'));
+  }
+
+  // only show pipelines available for selected backend
   filterPipelineOptions();
   // load cli command
   generateCli();
@@ -59,11 +83,39 @@ document.getElementById("select-pipeline").onchange = function () {
 document.getElementById("query-copy-btn").onclick = function () {
   copyQuery();
 };
+document.getElementById("rule-share-btn").onclick = function () {
+  generateShareLink();
+};
+
+function generateShareLink() {
+  let backend = getSelectValue("select-backend");
+  let format = getSelectValue("select-format");
+  let rule = encodeURIComponent(btoa(sigmaJar.toString()));
+
+  // generate link with parameters
+  let shareParams =  "?backend=" + backend + "&format=" + format + "&rule=" + rule;
+  let shareUrl = location.protocol + "://" + location.host + "/" + shareParams;
+  window.history.pushState({}, null, shareParams);
+  
+  // copy link for sharing to clipboard
+  navigator.clipboard.writeText(shareUrl);
+
+  // toggle color for user feedback
+  var ruleShareBtn = document.getElementById("rule-share-btn");
+  ruleShareBtn.classList.toggle("text-sigma-blue");
+  ruleShareBtn.classList.toggle("text-green-400");
+
+  setTimeout(function () {
+    ruleShareBtn.classList.toggle("text-sigma-blue");
+    ruleShareBtn.classList.toggle("text-green-400");
+  }, 1200);
+}
 
 function copyQuery() {
   let queryCode = document.getElementById("query-code");
   navigator.clipboard.writeText(queryCode.value);
 
+  // toggle color for user feedback
   var queryCopyBtn = document.getElementById("query-copy-btn");
   queryCopyBtn.classList.toggle("text-sigma-blue");
   queryCopyBtn.classList.toggle("text-green-400");

--- a/static/js/index.js
+++ b/static/js/index.js
@@ -25,7 +25,21 @@ new TomSelect("#select-pipeline", {
 
 // inital stuff todo when page is loaded
 window.onload = function () {
-  const urlParameter = new URL(window.location.toLocaleString()).searchParams;
+  // Get the fragment section from the current URL, without the '#' character
+  const fragment = window.location.hash.substring(1);
+
+  // Split the hash into key-value pair strings
+  const pairs = fragment.split('&');
+
+  // Parse each pair into a key and a value and store them in a map
+  const urlParameter = new Map();
+  pairs.forEach(function(pair) {
+    const [key, value] = pair.split('=');
+    // If both key and value are present, decode and store them
+    if (key && value) {
+      urlParameter.set(decodeURIComponent(key), decodeURIComponent(value));
+    }
+  });
   
   // check if rule parameter is in url
   if(urlParameter.has('rule')){
@@ -93,7 +107,7 @@ function generateShareLink() {
   let rule = encodeURIComponent(btoa(sigmaJar.toString()));
 
   // generate link with parameters
-  let shareParams =  "?backend=" + backend + "&format=" + format + "&rule=" + rule;
+  let shareParams =  "#backend=" + backend + "&format=" + format + "&rule=" + rule;
   let shareUrl = location.protocol + "://" + location.host + "/" + shareParams;
   window.history.pushState({}, null, shareParams);
   

--- a/templates/index.html
+++ b/templates/index.html
@@ -83,7 +83,10 @@
       <div class="grid lg:grid-cols-2 gap-4">
         <div class="lg:col-span-1 self-start lg:px-2">
           <p class="text-lg text-white font-bold">
-            <span class="px-3 py-2 border-x border-t rounded border-sigma-blue">rule.yml</span>
+            <span class="px-3 py-2 border-x border-t rounded border-sigma-blue">
+              <i id="rule-share-btn" class="fas fa-share-nodes px-1 py-0 my-0 text-sm text-sigma-blue cursor-pointer"></i>
+              rule.yml
+            </span>
           </p>
           <pre onclick="focusSelect('rule-code')" class="border border-sigma-blue"><code id="rule-code" class="language-yaml text-sm">title: Suspicious SYSTEM User Process Creation
 id: 2617e7ed-adb7-40ba-b0f3-8f9945fe6c09


### PR DESCRIPTION
This pull request introduces the url parameters `backend`, `format` and `rule`   in the fragment section and a sharing button to generate a matching url to make it easy to share a users settings and rule input.
The fields `backend` and `format` take plaintext input and `rule` should be the base64 encoded sigma rule.

Example Usage:

- bookmark the page to always have your favorite backend pre-selected -> http://localhost:8000/#backend=sentinelone&format=json
- share a rule you created with the right backend and format -> http://localhost:8000/#backend=azure&format=default&rule=dGl0bGU6IEFkZGl0aW9uIG9mIERvbWFpbiBUcnVzdHMKaWQ6IDAyNTVhODIwLWU1NjQtNGU0MC1hZjJiLTZhYzYxMTYwMzM1YwpzdGF0dXM6IHN0YWJsZQpkZXNjcmlwdGlvbjogQWRkaXRpb24gb2YgZG9tYWlucyBpcyBzZWxkb20gYW5kIHNob3VsZCBiZSB2ZXJpZmllZCBmb3IgbGVnaXRpbWFjeS4KYXV0aG9yOiBUaG9tYXMgUGF0emtlCmRhdGU6IDIwMTkvMTIvMDMKdGFnczoKICAgIC0gYXR0YWNrLnBlcnNpc3RlbmNlCiAgICAtIGF0dGFjay50MTA5OApsb2dzb3VyY2U6CiAgICBwcm9kdWN0OiB3aW5kb3dzCiAgICBzZXJ2aWNlOiBzZWN1cml0eQpkZXRlY3Rpb246CiAgICBzZWxlY3Rpb246CiAgICAgICAgRXZlbnRJRDogNDcwNgogICAgY29uZGl0aW9uOiBzZWxlY3Rpb24KZmFsc2Vwb3NpdGl2ZXM6CiAgICAtIExlZ2l0aW1hdGUgZXh0ZW5zaW9uIG9mIGRvbWFpbiBzdHJ1Y3R1cmUKbGV2ZWw6IG1lZGl1bQo%3D
