### PR TITLE
fix generated sharing url

### DIFF
--- a/static/js/index.js
+++ b/static/js/index.js
@@ -108,7 +108,7 @@ function generateShareLink() {
 
   // generate link with parameters
   let shareParams =  "#backend=" + backend + "&format=" + format + "&rule=" + rule;
-  let shareUrl = location.protocol + "://" + location.host + "/" + shareParams;
+  let shareUrl = location.protocol + "//" + location.host + "/" + shareParams;
   window.history.pushState({}, null, shareParams);
   
   // copy link for sharing to clipboard


### PR DESCRIPTION
Just noticed that the generated URL is starting with `https:://` because the `location.protocol` (https://www.w3schools.com/jsref/prop_loc_protocol.asp) variable includes the colon (`:`).

This PR fixes this to generate URLs correctly starting with `https://`