### PR TITLE
added pipeline parameter to the url sharing feature

### DIFF
--- a/static/js/index.js
+++ b/static/js/index.js
@@ -69,6 +69,15 @@ window.onload = function () {
 
   // only show pipelines available for selected backend
   filterPipelineOptions();
+
+  let pipelineSelect = document.getElementById("select-pipeline");
+  if(urlParameter.has('pipeline')) {
+    const pipelineValues = urlParameter.get('pipeline').split(';');
+    pipelineValues.forEach(function(value) {
+      pipelineSelect.tomselect.addItem(value);
+    });
+  }
+
   // load cli command
   generateCli();
   // inital conversion of example rule
@@ -104,10 +113,11 @@ document.getElementById("rule-share-btn").onclick = function () {
 function generateShareLink() {
   let backend = getSelectValue("select-backend");
   let format = getSelectValue("select-format");
+  let pipelines = getSelectValue("select-pipeline");
   let rule = encodeURIComponent(btoa(sigmaJar.toString()));
 
   // generate link with parameters
-  let shareParams =  "#backend=" + backend + "&format=" + format + "&rule=" + rule;
+  let shareParams =  "#backend=" + backend + "&format=" + format + "&pipeline=" + pipelines.join(";") + "&rule=" + rule;
   let shareUrl = location.protocol + "//" + location.host + "/" + shareParams;
   window.history.pushState({}, null, shareParams);
   


### PR DESCRIPTION
The last PR #16 was missing the `pipeline` parameter in the URL. This PR now adds the parameter. To define multiple pipelines in the URL you can simply seperate them with a semicolon `;`. This is done automatically when pressing the share button.

Examples: 
http://localhost:8000/#backend=splunk&format=data_model&pipeline=splunk_cim 
http://localhost:8000/#backend=ibm-qradar-aql&format=default&pipeline=qradar-aql-fields;qradar-aql-payload