### PR TITLE
feat: add hide editor param

### DIFF
--- a/run.py
+++ b/run.py
@@ -4,7 +4,8 @@
 import os
 import yaml
 import base64
-from flask import Flask, render_template, request, Response
+import json
+from flask import Flask, jsonify, render_template, request, Response
 
 from sigma.conversion.base import Backend
 from sigma.plugins import InstalledSigmaPlugins
@@ -19,6 +20,7 @@ pipeline_generic = pipeline.ProcessingPipeline()
 backends = plugins.backends
 pipeline_resolver = plugins.get_pipeline_resolver()
 pipelines = list(pipeline_resolver.list_pipelines())
+pipelines_names = [p[0] for p in pipelines]
 
 
 @app.route("/")
@@ -39,6 +41,11 @@ def home():
     return render_template(
         "index.html", backends=backends, pipelines=pipelines, formats=formats
     )
+
+
+@app.route("/getpipelines", methods=["GET"])
+def get_pipelines():
+    return jsonify(pipelines_names)
 
 
 @app.route("/sigma", methods=["POST"])

--- a/static/js/index.js
+++ b/static/js/index.js
@@ -41,7 +41,7 @@ window.onload = function () {
     }
   });
   
-  // check if rule parameter is in url
+  // check if hideEditor parameter is in url
   if(urlParameter.has('hideEditor')){
     let hideEditor = urlParameter.get('hideEditor')
     if(hideEditor == 1){

--- a/static/js/index.js
+++ b/static/js/index.js
@@ -42,6 +42,15 @@ window.onload = function () {
   });
   
   // check if rule parameter is in url
+  if(urlParameter.has('hideEditor')){
+    let hideEditor = urlParameter.get('hideEditor')
+    if(hideEditor == 1){
+      document.getElementById("rule-section").style.display = "none"
+      document.getElementById("rule-grid").setAttribute("class", "")
+    }
+  }
+
+  // check if rule parameter is in url
   if(urlParameter.has('rule')){
     let rule = atob(urlParameter.get('rule'));
     sigmaJar.updateCode(rule)

--- a/templates/index.html
+++ b/templates/index.html
@@ -78,10 +78,9 @@
         </div>
       </div>
     </div>
-
     <div id="content-section" class="mx-10 mt-5">
-      <div class="grid lg:grid-cols-2 gap-4">
-        <div class="lg:col-span-1 self-start lg:px-2">
+      <div id="rule-grid" class="grid lg:grid-cols-2 gap-4">
+        <div id="rule-section" class="lg:col-span-1 self-start lg:px-2">
           <p class="text-lg text-white font-bold">
             <span class="px-3 py-2 border-x border-t rounded border-sigma-blue">
               <i id="rule-share-btn" class="fas fa-share-nodes px-1 py-0 my-0 text-sm text-sigma-blue cursor-pointer"></i>
@@ -169,7 +168,6 @@ falsepositives:
 level: high</code></pre>
           <pre onclick="focusSelect('pipeline-code')" class="border border-sigma-blue tab-code hidden"><code id="pipeline-code" class="language-yaml text-sm"></code></pre>
         </div>
-        
         <div class="lg:col-span-1 self-start lg:px-2">
           <p class="text-lg text-white font-bold">
             <span class="px-3 py-2 border-x border-t rounded border-sigma-blue">


### PR DESCRIPTION
This PR adds the following:

- And API endpoint to get the list of pipelines (this is a start and will add more functions in the near future to make it integrates with other products)
- Adds a `hideEditor` params that will be used with the Sigma vscode extension. Basically it'll allow people to modify and convert their stuff from vscode and only show the results. (see ss below for a somewhat of an example)

![image](https://github.com/magicsword-io/sigconverter.io/assets/8741929/80b33f75-5914-4bf3-8de0-42ca43fa4fd1)
 