### PR TITLE
fix: #26

### DIFF
--- a/static/css/style.css
+++ b/static/css/style.css
@@ -53,10 +53,18 @@ pre:has(> #pipeline-code:empty)::after {
   width: 20px;
 }
 
-div[class*="language-"],
-code[class*="language-"],
-code[class*="language-"] *,
-pre[class*="language-"] {
+div[class*="language-yaml"],
+code[class*="language-yaml"],
+code[class*="language-yaml"] *,
+pre[class*="language-yaml"] {
+  word-break: break-word !important;
+  white-space: pre !important;
+}
+
+div[class*="language-splunk"],
+code[class*="language-splunk"],
+code[class*="language-splunk"] *,
+pre[class*="language-splunk"] {
   word-break: break-word !important;
   white-space: pre-line !important;
 }

--- a/templates/index.html
+++ b/templates/index.html
@@ -175,7 +175,7 @@ level: high</code></pre>
               query
             </span>
           </p>
-          <pre class="border border-sigma-blue">
+          <pre class="border border-sigma-blue language-splunk-spl">
             <code id="query-code" class="language-splunk-spl text-sm">the generated query should be displayed here :)</code></pre>
         </div>
 


### PR DESCRIPTION
On browsers like firefox the indentation isn't preserved due the use of `pre-line` on the yaml portion. Just duplicate the css and used different values for tha output and the yaml.

Fixes #26 