### PR TITLE
do not use environment variable for backend port

### DIFF
--- a/backend/backend.py
+++ b/backend/backend.py
@@ -128,4 +128,4 @@ def convert():
 if __name__ == "__main__":
     current_version = metadata.version("sigma-cli")
     port = int(f'8{current_version.replace(".","")}')
-    app.run(host="0.0.0.0", port=int(os.environ.get("PORT", port)))
+    app.run(host="0.0.0.0", port=port)


### PR DESCRIPTION
This fixes the deployment in GCP. If the environment variable is set all backends try to run on the same port.