### PR TITLE
allow 'latest' for api endpoints instead of specifying a version

### DIFF
--- a/frontend/frontend.py
+++ b/frontend/frontend.py
@@ -19,6 +19,10 @@ def get_port_from_version(version):
     pattern = r"^\d+\.\d+\.\d+$"
     if re.match(pattern, version):
         return int(f'8{version.replace(".", "")}')
+    elif version == "latest":
+        latest_version = sorted(
+            sigma_versions, key=version_key, reverse=True)[0]
+        return int(f'8{latest_version.replace(".", "")}')
     else:
         return None
 


### PR DESCRIPTION
This PR allows "latest" instead of a version number so that API calls such as `/api/v1/latest/targets` or `/api/v1/latest/convert` are possible.