### PR TITLE
Fix CRLF line endings in Docker build

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -10,6 +10,7 @@ WORKDIR /app/
 COPY . /app
 
 # install backend
+RUN find /app -type f -exec sed -i 's/\r$//' {} +
 RUN cd backend && ./setup-sigma-versions.sh
 
 # launch front- and backend


### PR DESCRIPTION
Docker option did not work at Windows machine. I applied a quick fix by adding a line in Dockerfile to conver CRLF to LF. There might be better way, it just a quick workaround.


The error is at below. After solution, it is working on Unix and Windows.

![image](https://github.com/user-attachments/assets/5fa30e3f-3992-41f0-bbc8-55ef57d7b59c)
