### PR TITLE
disable html encoding by default for api calls

### DIFF
--- a/backend/backend.py
+++ b/backend/backend.py
@@ -97,6 +97,9 @@ def convert():
 
     target = request.json["target"]
     format = request.json["format"]
+    html_escape = False
+    if request.json.get("html") == "true":
+        html_escape = True
 
     try:
         backend_class = backends[target]
@@ -123,8 +126,11 @@ def convert():
         return Response(f"SigmaError: {str(e)}", status=400, mimetype="text/html")
     except Exception as e:
         return Response(f"UnknownError: {str(e)}", status=400, mimetype="text/html")
+    
+    if(html_escape):
+        result = html.escape(result)
 
-    return html.escape(result)
+    return result
 
 if __name__ == "__main__":
     current_version = metadata.version("sigma-cli")

--- a/frontend/static/js/index.js
+++ b/frontend/static/js/index.js
@@ -313,6 +313,7 @@ function convert(sigmaRule, customPipeline) {
     pipeline: pipelines,
     target: backend,
     format: format,
+    html: "true"
   };
 
   // send post request


### PR DESCRIPTION
This PR is an extension to the previous one #65 

To not break the response behavior for API users the html encoding is disabled by default.
Only when the `/convert` endpoint is called with `?html=true` parameter it will encode the special characters.
This parameter will be used by our frontend.