### PR TITLE
bump deprecated docker image & exclude sigma-cli release candidate versions

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM python:3.11.4-slim-buster
+FROM python:3.11.4-slim-bookworm
 
 # install dependencies
 RUN apt-get update 

--- a/backend/setup-sigma-versions.sh
+++ b/backend/setup-sigma-versions.sh
@@ -1,7 +1,7 @@
 #!/bin/bash
 
 # fetch 10 latest versions of sigma-cli
-SIGMA_VERSIONS=$(curl -s https://pypi.org/pypi/sigma-cli/json | jq -r '.releases | keys | .[-10:] | .[]')
+SIGMA_VERSIONS=$(curl -s https://pypi.org/pypi/sigma-cli/json | jq -r '.releases | keys | map(select(contains("rc") | not)) | .[-10:] | .[]')
 
 # prepare virtualenv for each version
 for VERSION in $SIGMA_VERSIONS; do


### PR DESCRIPTION
- update deprecated python docker image from debian `buster` to `bookworm` / fixes #67 
- exclude release candidate versions of `sigma-cli` because they break the current implementation for backend/port mapping
