### PR TITLE
add: optional backends.txt for backend selection + filters for exclusions

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,6 @@
+# Custom
+backends.txt
+
 # Byte-compiled / optimized / DLL files
 __pycache__/
 *.py[cod]
@@ -158,3 +161,6 @@ cython_debug/
 #  and can be added to the global gitignore or merged into this file.  For a more nuclear
 #  option (not recommended) you can uncomment the following to ignore the entire idea folder.
 #.idea/
+
+# user-specific backend selection (see backends.txt.example)
+/backends.txt

--- a/Dockerfile
+++ b/Dockerfile
@@ -12,6 +12,9 @@ COPY . /app
 # install backend
 RUN cd backend && ./setup-sigma-versions.sh
 
+# install frontend dependencies
+RUN cd frontend && uv sync
+
 # launch front- and backend
 EXPOSE 8000
 ENTRYPOINT ["./entrypoint.sh"]

--- a/README.md
+++ b/README.md
@@ -26,6 +26,12 @@ cd backend && ./setup-sigma-versions.sh && cd ..
 ./entrypoint.sh
 ```
 
+### With Docker Compose (recommended):
+
+```bash
+docker compose -f docker-compose.prod.yml up -d --build
+```
+
 ### With Docker:
 
 ```bash

--- a/README.md
+++ b/README.md
@@ -26,6 +26,8 @@ cd backend && ./setup-sigma-versions.sh && cd ..
 ./entrypoint.sh
 ```
 
+By default, `setup-sigma-versions.sh` installs every backend from the [SigmaHQ plugin directory](https://github.com/SigmaHQ/pySigma-plugin-directory). To install only a curated subset (faster builds, smaller image), copy `backends.txt.example` to `backends.txt` at the repo root and edit it, one package per line. Optionally, override the path with the `BACKENDS_FILE` environment variable.
+
 ### With Docker Compose (recommended):
 
 ```bash

--- a/README.md
+++ b/README.md
@@ -28,7 +28,7 @@ cd backend && ./setup-sigma-versions.sh && cd ..
 
 By default, `setup-sigma-versions.sh` installs every backend from the [SigmaHQ plugin directory](https://github.com/SigmaHQ/pySigma-plugin-directory). To install only a curated subset (faster builds, smaller image), copy `backends.txt.example` to `backends.txt` at the repo root and edit it, one package per line. Optionally, override the path with the `BACKENDS_FILE` environment variable.
 
-### With Docker Compose (recommended):
+### With Docker Compose:
 
 ```bash
 docker compose -f docker-compose.prod.yml up -d --build

--- a/backend/backend.py
+++ b/backend/backend.py
@@ -95,6 +95,19 @@ def convert():
                     f"YamlError: Malformed Pipeline Yaml", status=400, mimetype="text/html"
                 )
 
+    filter_yml = None
+    if request.json.get("filterYml"):
+        filter_yml = str(base64.b64decode(request.json["filterYml"]), "utf-8")
+        if filter_yml.strip():
+            try:
+                yaml.safe_load_all(filter_yml)
+            except:
+                return Response(
+                    f"YamlError: Malformed Filter Yaml", status=400, mimetype="text/html"
+                )
+        else:
+            filter_yml = None
+
     target = request.json["target"]
     format = request.json["format"]
     html_escape = False
@@ -118,7 +131,12 @@ def convert():
     backend: Backend = backend_class(processing_pipeline=processing_pipeline)
 
     try:
-        sigma_rule = SigmaCollection.from_yaml(rule)
+        if filter_yml:
+            combined_yaml = rule.rstrip() + "\n---\n" + filter_yml
+            sigma_rule = SigmaCollection.from_yaml(combined_yaml)
+            sigma_rule.resolve_rule_references()
+        else:
+            sigma_rule = SigmaCollection.from_yaml(rule)
         result = backend.convert(sigma_rule, format)
         if isinstance(result, list):
             result = result[0]

--- a/backend/setup-sigma-versions.sh
+++ b/backend/setup-sigma-versions.sh
@@ -3,6 +3,28 @@
 # fetch 10 latest versions of sigma-cli
 SIGMA_VERSIONS=$(curl -s https://pypi.org/pypi/sigma-cli/json | jq -r '.releases | keys | map(select(contains("rc") | not)) | .[-10:] | .[]')
 
+# optional: a backends.txt file (one package per line, '#' comments allowed)
+# selects which pySigma backends to install. If absent or empty, fall back to
+# installing the full SigmaHQ plugin directory. The script runs from backend/,
+# so the default lives at the repo root.
+BACKENDS_FILE="${BACKENDS_FILE:-../backends.txt}"
+
+# read user-selected backends, stripping comments and blank lines
+SELECTED_BACKENDS=()
+if [ -f "$BACKENDS_FILE" ]; then
+    while IFS= read -r line || [ -n "$line" ]; do
+        pkg="${line%%#*}"
+        pkg="$(echo "$pkg" | xargs)"
+        [ -n "$pkg" ] && SELECTED_BACKENDS+=("$pkg")
+    done < "$BACKENDS_FILE"
+fi
+
+if [ "${#SELECTED_BACKENDS[@]}" -gt 0 ]; then
+    echo "Installing ${#SELECTED_BACKENDS[@]} backend(s) from $BACKENDS_FILE"
+else
+    echo "No backends file found at $BACKENDS_FILE, using full SigmaHQ plugin directory"
+fi
+
 # prepare virtualenv for each version
 for VERSION in $SIGMA_VERSIONS; do
     # prepare folder to contain a single version
@@ -11,10 +33,31 @@ for VERSION in $SIGMA_VERSIONS; do
     cd $VERSION
     uv venv && uv -q pip sync pyproject.toml
 
-    # install sigma-cli and selected backends
     uv -q add sigma-cli==$VERSION
-    uv -q add pysigma-backend-splunk
-    uv -q add pySigma-backend-kusto
+
+    if [ "${#SELECTED_BACKENDS[@]}" -gt 0 ]; then
+        # install only the user-selected backends
+        for pkg in "${SELECTED_BACKENDS[@]}"; do
+            uv -q add "$pkg"
+        done
+    else
+        # fetch all plugins from plugin directory json and install latest compatible plugins available
+        curl https://raw.githubusercontent.com/SigmaHQ/pySigma-plugin-directory/refs/heads/main/pySigma-plugins-v1.json | jq '.plugins[].package' | xargs -n 1 uv add -q
+
+        # remove if installed because of https://github.com/redsand/pySigma-backend-hawk/issues/1
+        uv -q remove pySigma-backend-hawk
+
+        # some problems with kusto backend, disable for older sigma versions
+        if [[ $VERSION == 0.* ]]; then
+            uv -q remove pySigma-backend-kusto
+        fi
+
+        if [[ $VERSION == 2.* ]]; then
+            uv -q remove pySigma-backend-cortexxdr
+            uv -q remove pySigma-backend-opensearch
+            uv -q remove pysigma-backend-carbonblack
+        fi
+    fi
 
     # remove unused pyparsing imports in older version, see https://github.com/SigmaHQ/pySigma/pull/289#issuecomment-2410153076
     find ./ -iwholename "*sigma/conversion/base.py" -exec sed -i "/from pyparsing import Set/d" {} +

--- a/backend/setup-sigma-versions.sh
+++ b/backend/setup-sigma-versions.sh
@@ -11,23 +11,10 @@ for VERSION in $SIGMA_VERSIONS; do
     cd $VERSION
     uv venv && uv -q pip sync pyproject.toml
 
-    # fetch all plugins from plugin directory json and install latest compatible plugins available
+    # install sigma-cli and selected backends
     uv -q add sigma-cli==$VERSION
-    curl https://raw.githubusercontent.com/SigmaHQ/pySigma-plugin-directory/refs/heads/main/pySigma-plugins-v1.json | jq '.plugins[].package' | xargs -n 1 uv add -q
-
-    # remove if installed because of https://github.com/redsand/pySigma-backend-hawk/issues/1
-    uv -q remove pySigma-backend-hawk
-
-    # some problems with kusto backend, disable for older sigma versions
-    if [[ $VERSION == 0.* ]]; then
-        uv -q remove pySigma-backend-kusto
-    fi
-
-    if [[ $VERSION == 2.* ]]; then
-        uv -q remove pySigma-backend-cortexxdr
-        uv -q remove pySigma-backend-opensearch
-        uv -q remove pysigma-backend-carbonblack
-    fi
+    uv -q add pysigma-backend-splunk
+    uv -q add pySigma-backend-kusto
 
     # remove unused pyparsing imports in older version, see https://github.com/SigmaHQ/pySigma/pull/289#issuecomment-2410153076
     find ./ -iwholename "*sigma/conversion/base.py" -exec sed -i "/from pyparsing import Set/d" {} +

--- a/backends.txt.example
+++ b/backends.txt.example
@@ -1,0 +1,10 @@
+# Optional: list of pySigma backends to install (one per line, '#' for comments).
+# Copy this file to `backends.txt` (at the repo root) to use it. If `backends.txt`
+# is absent or empty, `backend/setup-sigma-versions.sh` will fall back to installing
+# the full SigmaHQ plugin directory (https://github.com/SigmaHQ/pySigma-plugin-directory).
+#
+# Override the path with the BACKENDS_FILE env var (relative to backend/, or absolute):
+#   BACKENDS_FILE=/path/to/my-backends.txt ./setup-sigma-versions.sh
+
+pysigma-backend-splunk
+pySigma-backend-kusto

--- a/docker-compose.prod.yml
+++ b/docker-compose.prod.yml
@@ -1,0 +1,12 @@
+services:
+  sigconverter:
+    build: .
+    ports:
+      - "8000:8000"
+    restart: unless-stopped
+    healthcheck:
+      test: ["CMD", "curl", "-f", "http://localhost:8000/"]
+      interval: 30s
+      timeout: 10s
+      retries: 3
+      start_period: 60s

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -1,4 +1,33 @@
 #!/bin/sh
 
 cd backend/ && ./launch-backends.sh && cd ..
+
+# wait for at least one backend to be ready before starting the frontend
+echo "Waiting for backends to start..."
+MAX_WAIT=30
+WAITED=0
+while [ $WAITED -lt $MAX_WAIT ]; do
+    # check if any backend port (8xxx) is listening
+    if ls /app/backend/ | grep -qE '^[0-9]+\.[0-9]+\.[0-9]+$'; then
+        for version_dir in /app/backend/[0-9]*/; do
+            version=$(basename "$version_dir")
+            port=$(echo "8${version}" | tr -d '.')
+            if curl -s -o /dev/null -w '' "http://localhost:${port}/api/v1/targets" 2>/dev/null; then
+                echo "Backend for sigma $version is ready on port $port"
+                READY=1
+                break
+            fi
+        done
+        [ "${READY:-0}" -eq 1 ] && break
+    fi
+    sleep 1
+    WAITED=$((WAITED + 1))
+    echo "Still waiting... ($WAITED/$MAX_WAIT)"
+done
+
+if [ "${READY:-0}" -ne 1 ]; then
+    echo "WARNING: No backends responded within ${MAX_WAIT}s. Starting frontend anyway."
+    echo "Check backend logs above for errors."
+fi
+
 cd frontend && uv run frontend.py

--- a/frontend/static/css/style.css
+++ b/frontend/static/css/style.css
@@ -36,6 +36,7 @@
 /* Code Area CSS */
 pre:has(> #rule-code),
 pre:has(> #pipeline-code),
+pre:has(> #filter-code),
 pre:has(> #query-code) {
   min-height: 200px;
   cursor: text;
@@ -49,6 +50,12 @@ pre:has(> #rule-code:empty)::after {
 
 pre:has(> #pipeline-code:empty)::after {
   content: "start writing your post processing pipeline...";
+  color: #c5c8c6;
+  width: 20px;
+}
+
+pre:has(> #filter-code:empty)::after {
+  content: "start writing your filter...";
   color: #c5c8c6;
   width: 20px;
 }

--- a/frontend/static/js/index.js
+++ b/frontend/static/js/index.js
@@ -74,6 +74,12 @@ window.onload = async function () {
     pipelineJar.updateCode(pipelineYml);
   }
 
+  // check if filterYml parameter is in url
+  if (urlParameter.has("filterYml")) {
+    let filterYml = base64Decode(urlParameter.get("filterYml"));
+    filterJar.updateCode(filterYml);
+  }
+
   let versionSelect = document.getElementById("select-sigma-version");
   if (urlParameter.has("version")) {
     versionSelect.tomselect.addItem(urlParameter.get("version"), true);
@@ -122,7 +128,7 @@ window.onload = async function () {
   // load cli command
   generateCli();
   // inital conversion of example rule
-  convert(sigmaJar.toString(), pipelineJar.toString());
+  convert(sigmaJar.toString(), pipelineJar.toString(), filterJar.toString());
 };
 
 // define onchange handler for select dropdowns
@@ -131,17 +137,17 @@ document.getElementById("select-backend").onchange = function () {
   filterFormatOptions();
   filterPipelineOptions();
   generateCli();
-  convert(sigmaJar.toString(), pipelineJar.toString());
+  convert(sigmaJar.toString(), pipelineJar.toString(), filterJar.toString());
 };
 
 document.getElementById("select-format").onchange = function () {
   generateCli();
-  convert(sigmaJar.toString(), pipelineJar.toString());
+  convert(sigmaJar.toString(), pipelineJar.toString(), filterJar.toString());
 };
 
 document.getElementById("select-pipeline").onchange = function () {
   generateCli();
-  convert(sigmaJar.toString(), pipelineJar.toString());
+  convert(sigmaJar.toString(), pipelineJar.toString(), filterJar.toString());
 };
 
 document.getElementById("select-sigma-version").onchange = async function () {
@@ -153,7 +159,7 @@ document.getElementById("select-sigma-version").onchange = async function () {
   filterFormatOptions();
   filterPipelineOptions();
   generateCli();
-  convert(sigmaJar.toString(), pipelineJar.toString());
+  convert(sigmaJar.toString(), pipelineJar.toString(), filterJar.toString());
 };
 
 // define onclick handler for buttons
@@ -168,6 +174,9 @@ document.getElementById("tab-rule").onclick = function () {
 };
 document.getElementById("tab-pipeline").onclick = function () {
   showTab("tab-pipeline", "pipeline-code");
+};
+document.getElementById("tab-filter").onclick = function () {
+  showTab("tab-filter", "filter-code");
 };
 document.getElementById("settings-btn").onclick = function () {
   let settingsModal = document.getElementById("settings-modal");
@@ -219,6 +228,7 @@ function generateShareLink() {
   let pipelines = getSelectValue("select-pipeline");
   let rule = encodeURIComponent(base64Encode(sigmaJar.toString()));
   let pipelineYml = encodeURIComponent(base64Encode(pipelineJar.toString()));
+  let filterYml = encodeURIComponent(base64Encode(filterJar.toString()));
 
   // generate link with parameters
   let shareParams =
@@ -233,7 +243,9 @@ function generateShareLink() {
     "&rule=" +
     rule +
     "&pipelineYml=" +
-    pipelineYml;
+    pipelineYml +
+    "&filterYml=" +
+    filterYml;
   let shareUrl = location.protocol + "//" + location.host + "/" + shareParams;
   window.history.pushState({}, null, shareParams);
 
@@ -294,12 +306,16 @@ function generateCli() {
     cliCommand = cliCommand + " -p pipeline.yml";
   }
 
+  if (filterJar.toString().length > 0) {
+    cliCommand = cliCommand + " --filter filter.yml";
+  }
+
   cliCommand = cliCommand + " -t " + backend + " -f " + format + " rule.yml";
   cliCode.innerHTML = cliCommand;
   Prism.highlightElement(cliCode); // rerun code highlighting
 }
 
-function convert(sigmaRule, customPipeline) {
+function convert(sigmaRule, customPipeline, customFilter) {
   let queryCode = document.getElementById("query-code");
 
   let backend = getSelectValue("select-backend");
@@ -310,6 +326,7 @@ function convert(sigmaRule, customPipeline) {
   const params = {
     rule: base64Encode(sigmaRule),
     pipelineYml: base64Encode(customPipeline),
+    filterYml: base64Encode(customFilter || ""),
     pipeline: pipelines,
     target: backend,
     format: format,

--- a/frontend/templates/index.html
+++ b/frontend/templates/index.html
@@ -91,6 +91,9 @@
             <span id="tab-pipeline" class="px-3 py-2 ml-1 border-x border-t rounded border-sigma-blue cursor-pointer file-tab">
               pipeline.yml
             </span>
+            <span id="tab-filter" class="px-3 py-2 ml-1 border-x border-t rounded border-sigma-blue cursor-pointer file-tab">
+              filter.yml
+            </span>
           </p>
           <pre onclick="focusSelect('rule-code')" class="border border-sigma-blue tab-code"><code id="rule-code" class="language-yaml text-sm">title: Suspicious SYSTEM User Process Creation
 id: 2617e7ed-adb7-40ba-b0f3-8f9945fe6c09
@@ -167,6 +170,7 @@ falsepositives:
     - Monitoring activity
 level: high</code></pre>
           <pre onclick="focusSelect('pipeline-code')" class="border border-sigma-blue tab-code hidden"><code id="pipeline-code" class="language-yaml text-sm"></code></pre>
+          <pre onclick="focusSelect('filter-code')" class="border border-sigma-blue tab-code hidden"><code id="filter-code" class="language-yaml text-sm"></code></pre>
         </div>
         <div class="lg:col-span-1 self-start lg:px-2">
           <p class="text-lg text-white font-bold">
@@ -227,7 +231,7 @@ level: high</code></pre>
     window.sigmaJar = CodeJar(document.querySelector('#rule-code'), el => Prism.highlightElement(el))
     sigmaJar.onUpdate(sigmaRule => {
       if (sigmaRule.length > 0) {
-        convert(sigmaRule, pipelineJar.toString());
+        convert(sigmaRule, pipelineJar.toString(), filterJar.toString());
       }
     })
 
@@ -235,7 +239,15 @@ level: high</code></pre>
     pipelineJar.onUpdate(pipelineYml => {
       generateCli();
       if (pipelineYml.length > 0) {
-        convert(sigmaJar.toString(), pipelineYml);
+        convert(sigmaJar.toString(), pipelineYml, filterJar.toString());
+      }
+    })
+
+    window.filterJar = CodeJar(document.querySelector('#filter-code'), el => Prism.highlightElement(el))
+    filterJar.onUpdate(filterYml => {
+      generateCli();
+      if (filterYml.length > 0) {
+        convert(sigmaJar.toString(), pipelineJar.toString(), filterYml);
       }
     })
   </script>


### PR DESCRIPTION
### Description

Two independent additions, both opt-in and backward-compatible:

- Optional backends.txt for backend selection (load a set of backends instead of all)
- filter.yml editor tab for testing rule exclusions

Also some minor change:

- Added a docker compose file
- Of course, update of the README.MD

#### Optional backend

- A new optional file at the repo root lets users install a curated subset of pySigma backends instead of the full SigmaHQ plugin directory. One PyPI package per line.
- If backends.txt (added in gitignore BTW) is absent or empty, it falls back to the existing "install everything from the plugin directory" path, including the version-specific compatibility removals (pySigma-backend-hawk, kusto on 0.x, the 2.x exclusions). Default upstream behavior is unchanged.

#### Filters editor tab

- A third editor tab to edit exclusions (filter.yml)
- Filter content is base64-encoded into the filterYml POST field, decoded server-side, validated as YAML, and merged with the rule before conversion.