### PR TITLE
fix: frontend pipeline filtering for multi-backend targets

### DIFF
--- a/frontend/static/js/index.js
+++ b/frontend/static/js/index.js
@@ -379,12 +379,16 @@ function filterPipelineOptions() {
   tomSelect.clear();
   tomSelect.clearOptions();
 
-  // only add the pipeplines which match the selected backend or have backend=="all"
+  // Only add pipelines that explicitly allow the selected backend or allow all backends.
   let backend = getSelectValue("select-backend");
-  var options = select.querySelectorAll(
-    'option[target$="' + backend + '"], option[target=""]',
-  );
+  var options = select.querySelectorAll("option");
   options = [...options];
+  options = options.filter((option) => {
+    const targets = option.dataset.targets
+      ? option.dataset.targets.split(",").filter(Boolean)
+      : [];
+    return targets.length === 0 || targets.includes(backend);
+  });
   options.forEach((option) => {
     tomSelect.addOption({
       label: option.label,
@@ -543,7 +547,7 @@ async function updatePipelines(version) {
       const option = document.createElement("option");
       option.value = item.name;
       option.textContent = item.name;
-      option.setAttribute("target", item.targets);
+      option.dataset.targets = item.targets.join(",");
       select.appendChild(option);
 
       tomSelect.addOption({


### PR DESCRIPTION
This fixes pipeline filtering in the frontend for Sigma CLI 3.x backends. Pipelines with multiple allowed backends were being serialized into a single string and filtered with a CSS suffix selector, which meant they only appeared for the backend listed last. This results that in the current deployment e.g. the `splunk_cim` pipeline is hidden when selecting the `splunk` backend and only shown for the `splunk_spl2` backend.

The fix changes pipeline filtering to treat the backend list as a list again: pipeline options now store their allowed backends in data-targets, and the dropdown filter parses that list and checks backend membership explicitly. As a result, pipelines allowed for both `splunk` and `splunk_spl2` now show up for both backends.