### PR TITLE
fix(ci): authenticate gcloud via auth action before setup-gcloud

### DIFF
--- a/.github/workflows/beta-deploy.yml
+++ b/.github/workflows/beta-deploy.yml
@@ -17,11 +17,15 @@ jobs:
     - name: Checkout code
       uses: actions/checkout@v6
 
+    - name: Authenticate to Google Cloud
+      uses: google-github-actions/auth@v2
+      with:
+        credentials_json: ${{ secrets.GCLOUD_AUTH }}
+
     - name: Setup Google Cloud SDK
-      uses: google-github-actions/setup-gcloud@v3
+      uses: google-github-actions/setup-gcloud@v2
       with:
         project_id: ${{ secrets.PROJECT_ID }}
-        service_account_key: ${{ secrets.GCLOUD_AUTH }}
 
     - name: Configure Docker
       run: gcloud auth configure-docker

--- a/.github/workflows/beta-deploy.yml
+++ b/.github/workflows/beta-deploy.yml
@@ -23,7 +23,7 @@ jobs:
         credentials_json: ${{ secrets.GCLOUD_AUTH }}
 
     - name: Setup Google Cloud SDK
-      uses: google-github-actions/setup-gcloud@v2
+      uses: google-github-actions/setup-gcloud@v3
       with:
         project_id: ${{ secrets.PROJECT_ID }}
 

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -17,11 +17,15 @@ jobs:
       - name: Checkout code
         uses: actions/checkout@v6
 
+      - name: Authenticate to Google Cloud
+        uses: google-github-actions/auth@v2
+        with:
+          credentials_json: ${{ secrets.GCLOUD_AUTH }}
+
       - name: Setup Google Cloud SDK
-        uses: google-github-actions/setup-gcloud@v3
+        uses: google-github-actions/setup-gcloud@v2
         with:
           project_id: ${{ secrets.PROJECT_ID }}
-          service_account_key: ${{ secrets.GCLOUD_AUTH }}
 
       - name: Configure Docker
         run: gcloud auth configure-docker

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -23,7 +23,7 @@ jobs:
           credentials_json: ${{ secrets.GCLOUD_AUTH }}
 
       - name: Setup Google Cloud SDK
-        uses: google-github-actions/setup-gcloud@v2
+        uses: google-github-actions/setup-gcloud@v3
         with:
           project_id: ${{ secrets.PROJECT_ID }}
 


### PR DESCRIPTION
The previous setup used setup-gcloud@v3 with service_account_key, which no longer authenticates automatically. This adds google-github-actions/auth@v2 with credentials_json before setup-gcloud@v2.