### PR TITLE
fix: remove redundant installation of packages in sigma plugin update workflow

### DIFF
--- a/.github/workflows/update-sigma-plugins.yml
+++ b/.github/workflows/update-sigma-plugins.yml
@@ -33,9 +33,6 @@ jobs:
       - name: Generate pinned sigma backend plugins
         run: python backend/update_sigma_plugins.py
 
-      - name: Install generated backend environments
-        run: ./backend/setup-sigma-plugins.sh
-
       - name: Validate generated backend startup
         run: ./backend/validate-backend-startup.sh
 


### PR DESCRIPTION
@josehelps small fix for the error in the test run: https://github.com/magicsword-io/sigconverter.io/actions/runs/27436824133/job/81100789179