### PR TITLE
chore: update deploy.yml to include min-instances for Cloud Run

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -37,4 +37,4 @@ jobs:
         run: gcloud builds submit --tag gcr.io/${{ secrets.PROJECT_ID }}/${{ env.IMAGE_NAME }}
 
       - name: Deploy to Google Cloud Run
-        run: gcloud run deploy ${{ env.SERVICE_NAME }} --image gcr.io/${{ secrets.PROJECT_ID }}/${{ env.IMAGE_NAME }} --platform managed --region us-central1
+        run: gcloud run deploy ${{ env.SERVICE_NAME }} --image gcr.io/${{ secrets.PROJECT_ID }}/${{ env.IMAGE_NAME }} --platform managed --region us-central1 --min-instances=1 


### PR DESCRIPTION
Add `--min-instances=1` to the Cloud Run deployment configuration to keep one instance warm and reduce cold starts after periods of inactivity.

When there is no traffic for some time, Cloud Run may scale the service down to zero instances. During a cold start, the frontend can already be served while the backend is still starting up. This makes the page appear broken until the backend is ready and the page is refreshed.

If the additional cost of keeping one instance running is not justified, we can revert to the current configuration.

Documentation: https://cloud.google.com/run/docs/configuring/min-instances